### PR TITLE
add scikit-learn package and issues to package.yml

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -23522,6 +23522,10 @@ science.js:
   version: 1.9.3-1
   bugs:
     - 876618
+scikit-learn:
+  version: 0.19.1-1
+  issues:
+    -randomness_in_documentation_generated_by_sphinx
 scilab:
   version: 5.5.2-4
   bugs:


### PR DESCRIPTION
scikit-learn debian package has reproducibility issues because of a dependency package, sphinx.
one issue is a random config idea generated by sphinx which I've submitted an issue for in the sphinx github already (https://github.com/sphinx-doc/sphinx/issues/4240).

other issues include capturing build path which seems to also be from sphinx considering the file it occurs in `/usr/share/doc/python-sklearn-doc/stable/_sources/auto_examples/index.rst.txt `